### PR TITLE
Optimize index computation

### DIFF
--- a/libm/acosf.c
+++ b/libm/acosf.c
@@ -61,20 +61,18 @@ double rlibm_acosf(float x) {
   }
   double atan_b = 0.0;
   if (R > 0.001953125) {
-    int l = 1;
-    int r = 256;
-    int m;
-    while (l < r) {
-      m = (l+r)/2;
-      if (0.00390625*m < R) {
-	l = m+1;
-      } else {
-	r = m;
-      }
+    int r;
+    {
+      double_x dx;
+      dx.d = R;
+      dx.x -= 1;
+      uint32_t value = 0x80 | ((dx.x >> 45) & 0x7f);
+      int exponent = dx.x >> 52;
+      r = value >> (8 - (exponent - 0x3f6));
     }
-    double b = r*0.00390625 - 0.001953125;
+    double b = r*0.00390625 + 0.001953125;
     R = (R - b)/(1.0L + b*R);
-    atan_b = atan_vals[r-1];
+    atan_b = atan_vals[r];
   }
   double R2 = R*R;
   y = 0x1.9e14ca1a8790bp-3;

--- a/libm/asinf.c
+++ b/libm/asinf.c
@@ -77,20 +77,18 @@ double rlibm_asinf(float x) {
   }
   double atan_b = 0.0;
   if (R > 0.001953125) {
-    int l = 1;
-    int r = 256;
-    int m;
-    while (l < r) {
-      m = (l+r)/2;
-      if (0.00390625*m < R) {
-	l = m+1;
-      } else {
-	r = m;
-      }
+    int r;
+    {
+      double_x dx;
+      dx.d = R;
+      dx.x -= 1;
+      uint32_t value = 0x80 | ((dx.x >> 45) & 0x7f);
+      int exponent = dx.x >> 52;
+      r = value >> (8 - (exponent - 0x3f6));
     }
-    double b = r*0.00390625 - 0.001953125;
+    double b = r*0.00390625 + 0.001953125;
     R = (R - b)/(1.0L + b*R);
-    atan_b = atan_vals[r-1];
+    atan_b = atan_vals[r];
   }
   double R2 = R*R;
   y = 0x1.9e14ca1a8790bp-3;

--- a/libm/atanf.c
+++ b/libm/atanf.c
@@ -64,20 +64,18 @@ double rlibm_atanf(float x) {
     }
     double atan_b = 0.0;
     if (R > 0.001953125) {
-      int l = 1;
-      int r = 256;
-      int m;
-      while (l < r) {
-	m = (l+r)/2;
-	if (0.00390625*m < R) {
-	  l = m+1;
-	} else {
-	  r = m;
-	}
+      int r;
+      {
+	double_x dx;
+	dx.d = R;
+	dx.x -= 1;
+	uint32_t value = 0x80 | ((dx.x >> 45) & 0x7f);
+	int exponent = dx.x >> 52;
+	r = value >> (8 - (exponent - 0x3f6));
       }
-      double b = r*0.00390625 - 0.001953125;
+      double b = r*0.00390625 + 0.001953125;
       R = (R - b)/(1.0L + b*R);
-      atan_b = atan_vals[r-1];
+      atan_b = atan_vals[r];
     }
     double R2 = R*R;
     y = 0x1.9e14ca1a8790bp-3;


### PR DESCRIPTION
Replace binary search index computation with straight-line bit manipulation in asinf(), acosf(), and atanf().
---

Hi there!

I noticed the while loop/binary search in the asinf/acosf/atanf functions, and took a shot at rewriting it as straight line code that operates directly on the bit-value of R.

To compute the appropriate 1/256 index bound, this change extracts the exponent and high 7 bits of the mantissa from R, prepends 1 to those bits, then shifts that value right based on the exponent. Because we know (1/512 < R <= 1), there's a small range of possible values that need to be considered.

I performed basic testing to confirm the output matches the original, for all single-precision floating point values, for each rounding mode.

I did very rudimentary speed testing: I'd estimate these changes cut down the total typical runtime of these functions by 10-20% - enough that it seems like it's worth sharing.

I recognize that this repository likely isn't the right or best place to land this change - I couldn't see the code that generates these functions in RLIBM-ALL, so I'm sharing this here as (hopefully) a stepping stone to finding the right place for it :slightly_smiling_face: