### PR TITLE
A sqrt that doesn't set errno

### DIFF
--- a/libm/acosf.c
+++ b/libm/acosf.c
@@ -28,6 +28,7 @@ SOFTWARE.
 #include <math.h>
 #include "pi.h"
 #include "rlibm.h"
+#include "sqrt.h"
 #define TRUE 1
 #define FALSE 0
 
@@ -53,7 +54,7 @@ double rlibm_acosf(float x) {
   }
   double y;
   double R = fx.f;
-  R = sqrt(1.0 - R*R)/R;
+  R = Sqrt(1.0 - R*R)/R;
   int reciprocal = FALSE;
   if (R > 1.0) {
     R = 1/R;

--- a/libm/asinf.c
+++ b/libm/asinf.c
@@ -28,6 +28,7 @@ SOFTWARE.
 #include <math.h>
 #include "pi.h"
 #include "rlibm.h"
+#include "sqrt.h"
 
 #define TRUE 1
 #define FALSE 0
@@ -69,7 +70,7 @@ double rlibm_asinf(float x) {
   }
   double y;
   double R = fx.f;
-  R /= sqrt(1.0 - R*R);
+  R /= Sqrt(1.0 - R*R);
   int reciprocal = FALSE;
   if (R > 1.0) {
     R = 1/R;

--- a/libm/sqrt.h
+++ b/libm/sqrt.h
@@ -1,0 +1,21 @@
+#if defined(__SSE2__)
+
+#include <emmintrin.h>
+
+static double Sqrt(double x)
+{
+    __m128d x_vec = _mm_set_pd(x, x);
+    __m128d sqrt_x = _mm_sqrt_sd(x_vec, x_vec);
+    return _mm_cvtsd_f64(sqrt_x);
+}
+
+#else
+
+#include <math.h>
+
+static double Sqrt(double x)
+{
+  return sqrt(x);
+}
+
+#endif


### PR DESCRIPTION
Hi again - another small optimization for your consideration.

A standards-compliant implementation of sqrt() will bounds-check it and set errno for invalid values - which is a significant overhead when a fast implementation of sqrt available.

One way to avoid the overhead is to compile with a flag like -fno-math-errno. Another is to use a custom sqrt() function, which is what this change does.

This change reduces runtime by ~5% for acos and asin, tested with the range of values that would not early out.